### PR TITLE
fix: configure Jest DOM type definitions for frontend tests

### DIFF
--- a/apps/web/ISSUE_238_SUMMARY.md
+++ b/apps/web/ISSUE_238_SUMMARY.md
@@ -1,0 +1,33 @@
+# Issue #238 - Fix Jest DOM Type Definitions
+
+## Summary
+Fixed TypeScript configuration to properly recognize Jest DOM matchers in frontend tests.
+
+## Changes Made
+
+1. **Created `jest-setup.ts`** - A setup file that imports `@testing-library/jest-dom` to ensure the matchers are available
+2. **Updated `jest.config.js`** - Added the new setup file to `setupFilesAfterEnv` array
+3. **Updated `tsconfig.json`** - Added `"node"` to the types array
+4. **Updated `jest-dom.d.ts`** - Simplified to just import the jest-dom types
+
+## Technical Details
+
+The issue was that TypeScript couldn't find the Jest DOM matcher types like `toBeInTheDocument`, `toHaveClass`, etc. even though `@testing-library/jest-dom` was installed.
+
+The solution involved:
+- Creating a dedicated setup file for the web project
+- Ensuring the setup file is loaded by Jest
+- Properly configuring TypeScript to include the necessary type definitions
+
+## Branch
+- `frontend/fix-jest-dom-types`
+
+## Next Steps
+- Create a PR for review
+- The TypeScript errors for Jest DOM matchers should be resolved
+- Tests should run correctly with proper type support
+
+## Notes
+- There are still other TypeScript errors in the project unrelated to Jest DOM types
+- The `@testing-library/jest-dom` v6.6.3 includes built-in TypeScript types
+- No additional `@types` packages are needed

--- a/apps/web/jest-setup.ts
+++ b/apps/web/jest-setup.ts
@@ -1,0 +1,2 @@
+// Import jest-dom to extend Jest matchers
+import '@testing-library/jest-dom';

--- a/apps/web/jest.config.js
+++ b/apps/web/jest.config.js
@@ -7,6 +7,7 @@ const webProjectConfig = rootConfig.projects.find((project) => project.displayNa
 module.exports = {
   ...webProjectConfig,
   rootDir: '../..',
+  setupFilesAfterEnv: ['<rootDir>/jest.setup.js', '<rootDir>/apps/web/jest-setup.ts'],
   // Override paths to be relative to this file
   testMatch: ['<rootDir>/apps/web/**/__tests__/**/*.(test|spec).(ts|tsx|js|jsx)'],
   coverageDirectory: '<rootDir>/apps/web/coverage',
@@ -21,55 +22,76 @@ module.exports = {
   // Add resolver to handle convex imports
   resolver: '<rootDir>/jest.resolver.js',
   // Don't ignore convex files for transformation
-  transformIgnorePatterns: [
-    'node_modules/(?!(convex|@radix-ui|cmdk)/)',
-    '!convex/_generated/',
-  ],
+  transformIgnorePatterns: ['node_modules/(?!(convex|@radix-ui|cmdk)/)', '!convex/_generated/'],
   // Transform JS files from convex
   transform: {
     ...webProjectConfig.transform,
-    '^.+\\.(js|jsx)$': ['ts-jest', {
-      tsconfig: {
-        jsx: 'react',
-        allowJs: true,
-        esModuleInterop: true,
+    '^.+\\.(js|jsx)$': [
+      'ts-jest',
+      {
+        tsconfig: {
+          jsx: 'react',
+          allowJs: true,
+          esModuleInterop: true,
+        },
       },
-    }],
+    ],
     // Transform convex generated files specifically
-    '^.+convex/_generated/.+\\.js$': ['ts-jest', {
-      tsconfig: {
-        allowJs: true,
-        esModuleInterop: true,
-        module: 'commonjs',
+    '^.+convex/_generated/.+\\.js$': [
+      'ts-jest',
+      {
+        tsconfig: {
+          allowJs: true,
+          esModuleInterop: true,
+          module: 'commonjs',
+        },
       },
-    }],
+    ],
   },
   moduleNameMapper: {
     // Mock all variations of convex imports - order matters!
-    '^@/\\.\\./\\.\\./\\.\\./convex/_generated/api(\\.js)?$': '<rootDir>/apps/web/src/__tests__/__mocks__/convex-api.js',
-    '^@/\\.\\./\\.\\./\\.\\./convex/_generated/dataModel(\\.d?\\.ts)?$': '<rootDir>/apps/web/src/__tests__/__mocks__/convex-dataModel.ts',
-    '^(\\.{1,2}/)*\\.\\./convex/_generated/api(\\.js)?$': '<rootDir>/apps/web/src/__tests__/__mocks__/convex-api.js',
-    '^(\\.{1,2}/)*\\.\\./convex/_generated/dataModel(\\.d?\\.ts)?$': '<rootDir>/apps/web/src/__tests__/__mocks__/convex-dataModel.ts',
-    '\\.\\./\\.\\./\\.\\./\\.\\./\\.\\./convex/_generated/api(\\.js)?$': '<rootDir>/apps/web/src/__tests__/__mocks__/convex-api.js',
-    '\\.\\./\\.\\./\\.\\./\\.\\./\\.\\./convex/_generated/api$': '<rootDir>/apps/web/src/__tests__/__mocks__/convex-api.js',
-    '\\.\\./\\.\\./\\.\\./\\.\\./\\.\\./\\.\\./convex/_generated/api(\\.js)?$': '<rootDir>/apps/web/src/__tests__/__mocks__/convex-api.js',
-    '\\.\\./\\.\\./\\.\\./\\.\\./\\.\\./\\.\\./\\.\\./convex/_generated/api(\\.js)?$': '<rootDir>/apps/web/src/__tests__/__mocks__/convex-api.js',
-    '\\.\\./\\.\\./\\.\\./\\.\\./\\.\\./convex/_generated/dataModel(\\.d?\\.ts)?$': '<rootDir>/apps/web/src/__tests__/__mocks__/convex-dataModel.ts',
-    '\\.\\./\\.\\./\\.\\./\\.\\./\\.\\./\\.\\./convex/_generated/dataModel(\\.d?\\.ts)?$': '<rootDir>/apps/web/src/__tests__/__mocks__/convex-dataModel.ts',
-    '\\.\\./\\.\\./\\.\\./\\.\\./\\.\\./\\.\\./\\.\\./convex/_generated/dataModel(\\.d?\\.ts)?$': '<rootDir>/apps/web/src/__tests__/__mocks__/convex-dataModel.ts',
+    '^@/\\.\\./\\.\\./\\.\\./convex/_generated/api(\\.js)?$':
+      '<rootDir>/apps/web/src/__tests__/__mocks__/convex-api.js',
+    '^@/\\.\\./\\.\\./\\.\\./convex/_generated/dataModel(\\.d?\\.ts)?$':
+      '<rootDir>/apps/web/src/__tests__/__mocks__/convex-dataModel.ts',
+    '^(\\.{1,2}/)*\\.\\./convex/_generated/api(\\.js)?$':
+      '<rootDir>/apps/web/src/__tests__/__mocks__/convex-api.js',
+    '^(\\.{1,2}/)*\\.\\./convex/_generated/dataModel(\\.d?\\.ts)?$':
+      '<rootDir>/apps/web/src/__tests__/__mocks__/convex-dataModel.ts',
+    '\\.\\./\\.\\./\\.\\./\\.\\./\\.\\./convex/_generated/api(\\.js)?$':
+      '<rootDir>/apps/web/src/__tests__/__mocks__/convex-api.js',
+    '\\.\\./\\.\\./\\.\\./\\.\\./\\.\\./convex/_generated/api$':
+      '<rootDir>/apps/web/src/__tests__/__mocks__/convex-api.js',
+    '\\.\\./\\.\\./\\.\\./\\.\\./\\.\\./\\.\\./convex/_generated/api(\\.js)?$':
+      '<rootDir>/apps/web/src/__tests__/__mocks__/convex-api.js',
+    '\\.\\./\\.\\./\\.\\./\\.\\./\\.\\./\\.\\./\\.\\./convex/_generated/api(\\.js)?$':
+      '<rootDir>/apps/web/src/__tests__/__mocks__/convex-api.js',
+    '\\.\\./\\.\\./\\.\\./\\.\\./\\.\\./convex/_generated/dataModel(\\.d?\\.ts)?$':
+      '<rootDir>/apps/web/src/__tests__/__mocks__/convex-dataModel.ts',
+    '\\.\\./\\.\\./\\.\\./\\.\\./\\.\\./\\.\\./convex/_generated/dataModel(\\.d?\\.ts)?$':
+      '<rootDir>/apps/web/src/__tests__/__mocks__/convex-dataModel.ts',
+    '\\.\\./\\.\\./\\.\\./\\.\\./\\.\\./\\.\\./\\.\\./convex/_generated/dataModel(\\.d?\\.ts)?$':
+      '<rootDir>/apps/web/src/__tests__/__mocks__/convex-dataModel.ts',
     '^convex/_generated/api(\\.js)?$': '<rootDir>/apps/web/src/__tests__/__mocks__/convex-api.js',
     '^convex/_generated/api\\.js$': '<rootDir>/apps/web/src/__tests__/__mocks__/convex-api.js',
-    '^convex/_generated/dataModel(\\.d?\\.ts)?$': '<rootDir>/apps/web/src/__tests__/__mocks__/convex-dataModel.ts',
+    '^convex/_generated/dataModel(\\.d?\\.ts)?$':
+      '<rootDir>/apps/web/src/__tests__/__mocks__/convex-dataModel.ts',
     '^@convex/_generated/api$': '<rootDir>/apps/web/src/__tests__/__mocks__/convex-api.js',
-    '^@convex/_generated/dataModel$': '<rootDir>/apps/web/src/__tests__/__mocks__/convex-dataModel.ts',
+    '^@convex/_generated/dataModel$':
+      '<rootDir>/apps/web/src/__tests__/__mocks__/convex-dataModel.ts',
     ...webProjectConfig.moduleNameMapper,
     // Mock Radix UI packages
     '^@radix-ui/react-icons$': '<rootDir>/apps/web/src/__tests__/__mocks__/lucide-react.js',
-    '^@radix-ui/react-dialog$': '<rootDir>/apps/web/src/__tests__/__mocks__/@radix-ui/react-dialog.js',
-    '^@radix-ui/react-popover$': '<rootDir>/apps/web/src/__tests__/__mocks__/@radix-ui/react-popover.js',
-    '^@radix-ui/react-scroll-area$': '<rootDir>/apps/web/src/__tests__/__mocks__/@radix-ui/react-scroll-area.js',
-    '^@radix-ui/react-label$': '<rootDir>/apps/web/src/__tests__/__mocks__/@radix-ui/react-label.js',
-    '^@radix-ui/react-select$': '<rootDir>/apps/web/src/__tests__/__mocks__/@radix-ui/react-select.js',
+    '^@radix-ui/react-dialog$':
+      '<rootDir>/apps/web/src/__tests__/__mocks__/@radix-ui/react-dialog.js',
+    '^@radix-ui/react-popover$':
+      '<rootDir>/apps/web/src/__tests__/__mocks__/@radix-ui/react-popover.js',
+    '^@radix-ui/react-scroll-area$':
+      '<rootDir>/apps/web/src/__tests__/__mocks__/@radix-ui/react-scroll-area.js',
+    '^@radix-ui/react-label$':
+      '<rootDir>/apps/web/src/__tests__/__mocks__/@radix-ui/react-label.js',
+    '^@radix-ui/react-select$':
+      '<rootDir>/apps/web/src/__tests__/__mocks__/@radix-ui/react-select.js',
     '^@radix-ui/react-slot$': '<rootDir>/apps/web/src/__tests__/__mocks__/@radix-ui/react-slot.js',
     '^@radix-ui/(.*)$': '<rootDir>/apps/web/src/__tests__/__mocks__/radix-ui-all.js',
     // Mock lucide-react
@@ -83,6 +105,7 @@ module.exports = {
     // Mock loading component
     '^@/components/loading$': '<rootDir>/apps/web/src/__tests__/__mocks__/loading.tsx',
     // Mock accessibility context
-    '^@/contexts/accessibility/AccessibilityContext$': '<rootDir>/apps/web/src/__tests__/__mocks__/contexts/accessibility/AccessibilityContext.tsx',
+    '^@/contexts/accessibility/AccessibilityContext$':
+      '<rootDir>/apps/web/src/__tests__/__mocks__/contexts/accessibility/AccessibilityContext.tsx',
   },
 };

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -4,22 +4,12 @@
   "compilerOptions": {
     "baseUrl": ".",
     "paths": {
-      "@/*": [
-        "./src/*"
-      ],
-      "~/*": [
-        "./*"
-      ],
-      "@convex/*": [
-        "../../convex/*"
-      ]
+      "@/*": ["./src/*"],
+      "~/*": ["./*"],
+      "@convex/*": ["../../convex/*"]
     },
     "allowSyntheticDefaultImports": true,
-    "types": [
-      "jest",
-      "@testing-library/jest-dom",
-      "jest-axe"
-    ],
+    "types": ["jest", "@testing-library/jest-dom", "jest-axe", "node"],
     "skipLibCheck": true,
     "allowJs": true,
     "noImplicitAny": false,
@@ -44,9 +34,5 @@
     "src/types/jest-dom.d.ts",
     "src/types/**/*.d.ts"
   ],
-  "exclude": [
-    "node_modules",
-    "coverage",
-    ".next/server"
-  ]
+  "exclude": ["node_modules", "coverage", ".next/server"]
 }


### PR DESCRIPTION
## Issue #238 - Fix Jest DOM Type Definitions

### Changes
- Created `jest-setup.ts` to import @testing-library/jest-dom
- Updated `jest.config.js` to include the new setup file
- Updated `tsconfig.json` to add "node" to types array
- Fixed `jest-dom.d.ts` to use import syntax instead of triple-slash reference

### Technical Details
This PR fixes TypeScript errors where Jest DOM matchers like `toBeInTheDocument`, `toHaveClass`, etc. were not being recognized in frontend tests.

### Testing
- Jest DOM matchers should now work without TypeScript errors
- Tests should run correctly with proper type support

Fixes #238