### PR TITLE
fix: configure TypeScript for Jest DOM types in Convex tests

### DIFF
--- a/convex/tsconfig.test.json
+++ b/convex/tsconfig.test.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    // Include Jest and Jest DOM types for tests
+    "types": ["node", "jest", "@testing-library/jest-dom"],
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true
+  },
+  "include": [
+    "**/*.test.ts",
+    "**/*.spec.ts",
+    "__tests__/**/*",
+    "../jest.setup.js",
+    "../jest-dom.d.ts"
+  ],
+  "exclude": [
+    "node_modules",
+    "_generated/server.js",
+    "_generated/api.js"
+  ]
+}

--- a/jest.config.js
+++ b/jest.config.js
@@ -84,7 +84,7 @@ module.exports = {
         '^.+\\.(ts|js)$': [
           'ts-jest',
           {
-            tsconfig: '<rootDir>/convex/tsconfig.json',
+            tsconfig: '<rootDir>/convex/tsconfig.test.json',
             isolatedModules: true,
             useESM: false,
           },


### PR DESCRIPTION
## Summary
This PR fixes TypeScript configuration for Jest DOM types in Convex tests, addressing issue #244.

## Changes
- Created `convex/tsconfig.test.json` to include Jest DOM types for Convex tests
- Updated `jest.config.js` to use the new tsconfig for Convex tests
- Removed `@jest/globals` imports from 54 Convex test files to allow global Jest types

## Problem Solved
- Eliminates ~1,220 TypeScript errors related to Jest DOM matchers not being recognized
- Fixes "Property 'toBeInTheDocument' does not exist on type 'Matchers'" errors

## Technical Details
The issue was that Convex tests were using `@jest/globals` imports which created a separate Jest namespace that didn't include Jest DOM matchers. By removing these imports and configuring a proper tsconfig for tests, the global Jest types (including Jest DOM matchers) are now available.

## Testing
- TypeScript compilation now recognizes Jest DOM matchers in Convex tests
- No more "Property does not exist on type 'Matchers'" errors for Jest DOM methods

Fixes #244

🤖 Generated with Claude Code