### PR TITLE
feat: Implement active task limits and status enforcement

### DIFF
--- a/Launch Multi-Agent System.md
+++ b/Launch Multi-Agent System.md
@@ -74,6 +74,32 @@ export ENABLE_WORKTREES=true
 
 Each agent will have their own worktree at `.worktrees/[agent-name]` for isolated development.
 
+## Task Management Rules (Issue #144)
+
+### Active Task Limits
+- **Maximum 3 active tasks per agent** - Enforced automatically
+- When claiming tasks: `claim_task <task-id> <agent-name>` (will fail if at limit)
+- When starting work: `start_task <task-id> <agent-name>` to mark as in-progress
+- Monitor limits: `./scripts/monitor-task-limits.sh`
+
+### Task Status Workflow
+1. **claim_task** → Creates `status-not-started` label
+2. **start_task** → Updates to `status-in-progress` (max 3 per agent)
+3. **update_task_status** → Changes status (blocked/review/done)
+
+### Monitoring Commands
+```bash
+# Check your active task count
+source scripts/migration/task_lib.sh
+get_active_task_count <agent-name>
+
+# View all agent workloads
+get_agent_workload_summary
+
+# Check for stale tasks
+check_stale_tasks
+```
+
 ## Phase 3: Launch the Multi-Agent System (10 Agents Total)
 
 ### **Terminal 1: Frontend Agent**

--- a/scripts/migration/task_lib.sh
+++ b/scripts/migration/task_lib.sh
@@ -4,6 +4,9 @@
 # Provides unified interface for agents to work with both AGENTS_BOARD.md and GitHub Issues
 # Enhanced with Git Worktree support for isolated agent development
 
+# Mark as loaded to prevent circular sourcing
+export TASK_LIB_LOADED=1
+
 # Configuration
 TASK_SYSTEM="${TASK_SYSTEM:-board}"
 BOARD_FILE="${BOARD_FILE:-AGENTS_BOARD.md}"
@@ -562,4 +565,13 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
     echo "  AGENT_NAME=${AGENT_NAME}"
     echo "  ENABLE_WORKTREES=${ENABLE_WORKTREES} (true|false)"
     echo "  WORKTREE_BASE=${WORKTREE_BASE}"
+fi
+
+# Enable enhanced task library with active task limits (Issue #144)
+# This adds enforcement of max 3 active tasks per agent
+# Prevent circular sourcing
+TASK_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+if [ -z "$TASK_LIB_ENHANCED_LOADED" ] && [ -f "$TASK_LIB_DIR/task_lib_enhanced.sh" ]; then
+    export TASK_LIB_ENHANCED_LOADED=1
+    source "$TASK_LIB_DIR/task_lib_enhanced.sh" 2>&1
 fi

--- a/scripts/migration/task_lib_enhanced.sh
+++ b/scripts/migration/task_lib_enhanced.sh
@@ -3,9 +3,11 @@
 # Implements task limits and status enforcement for agents
 # Based on Issue #144 requirements
 
-# Source the original task_lib.sh
+# Source the original task_lib.sh (if not already loaded)
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-source "$SCRIPT_DIR/task_lib.sh"
+if [ -z "$TASK_LIB_LOADED" ]; then
+    source "$SCRIPT_DIR/task_lib.sh"
+fi
 
 # Configuration
 MAX_ACTIVE_TASKS="${MAX_ACTIVE_TASKS:-3}"
@@ -122,7 +124,14 @@ get_active_tasks() {
 # Check for stale tasks and auto-revert
 check_stale_tasks() {
     local agent_name="${1:-all}"
-    local cutoff_date=$(date -u -v-${STALE_TASK_HOURS}H +%Y-%m-%dT%H:%M:%SZ)
+    # Handle both macOS and Linux date commands
+    if date -v-1H >/dev/null 2>&1; then
+        # macOS
+        local cutoff_date=$(date -u -v-${STALE_TASK_HOURS}H +%Y-%m-%dT%H:%M:%SZ)
+    else
+        # Linux
+        local cutoff_date=$(date -u -d "${STALE_TASK_HOURS} hours ago" +%Y-%m-%dT%H:%M:%SZ)
+    fi
     
     echo -e "${YELLOW}Checking for stale tasks (no update in ${STALE_TASK_HOURS}h)...${NC}"
     

--- a/scripts/monitor-task-limits.sh
+++ b/scripts/monitor-task-limits.sh
@@ -1,0 +1,87 @@
+#!/bin/bash
+# Monitor Task Limits for Multi-Agent System
+# Issue #144 - Enforce max 3 active tasks per agent
+
+# Source the task library with enhanced functions
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/migration/task_lib.sh"
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+PURPLE='\033[0;35m'
+NC='\033[0m'
+BOLD='\033[1m'
+
+# Show header
+echo -e "${BOLD}${BLUE}╔════════════════════════════════════════════════════════════════╗${NC}"
+echo -e "${BOLD}${BLUE}║                  TASK LIMIT MONITORING DASHBOARD               ║${NC}"
+echo -e "${BOLD}${BLUE}╚════════════════════════════════════════════════════════════════╝${NC}"
+echo -e "${YELLOW}Generated: $(date)${NC}\n"
+
+# Show configuration
+echo -e "${BOLD}Configuration:${NC}"
+echo -e "  Max Active Tasks: ${GREEN}${MAX_ACTIVE_TASKS:-3}${NC}"
+echo -e "  Stale Task Hours: ${YELLOW}${STALE_TASK_HOURS:-24}${NC}"
+echo -e "  Task System: ${BLUE}${TASK_SYSTEM:-github}${NC}"
+echo ""
+
+# Check if we're in GitHub mode
+if [ "${TASK_SYSTEM:-github}" != "github" ]; then
+    echo -e "${YELLOW}Warning: Task limits only enforced in GitHub mode${NC}"
+    echo -e "Set TASK_SYSTEM=github to enable enforcement"
+    exit 0
+fi
+
+# Show agent workload summary
+echo -e "${BOLD}${PURPLE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+get_agent_workload_summary
+
+# Check for stale tasks
+echo -e "\n${BOLD}${PURPLE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+check_stale_tasks
+
+# Enforce task limits
+echo -e "\n${BOLD}${PURPLE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+enforce_task_limits
+
+# Show P0 issues
+echo -e "\n${BOLD}${PURPLE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+echo -e "${BOLD}${RED}P0 Priority Issues:${NC}"
+gh issue list --label "priority-P0" --state open --limit 10 \
+    --json number,title,assignees \
+    --jq '.[] | "  #\(.number): \(.title)"'
+
+# Summary
+echo -e "\n${BOLD}${PURPLE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+echo -e "${BOLD}Summary:${NC}"
+
+# Count total active tasks
+total_active=$(gh issue list --label "status-in-progress" --state open --limit 200 --json number | jq 'length')
+echo -e "  Total Active Tasks: ${YELLOW}$total_active${NC}"
+
+# Count agents at limit
+agents_at_limit=0
+agents=$(gh label list --limit 100 --json name | jq -r '.[] | select(.name | startswith("agent-")) | .name' | sed 's/agent-//' | sort -u)
+for agent in $agents; do
+    active=$(get_active_task_count "$agent")
+    if [ "$active" -ge "${MAX_ACTIVE_TASKS:-3}" ]; then
+        ((agents_at_limit++))
+    fi
+done
+echo -e "  Agents at Limit: ${RED}$agents_at_limit${NC}"
+
+# Provide recommendations
+echo -e "\n${BOLD}Recommendations:${NC}"
+if [ "$agents_at_limit" -gt 0 ]; then
+    echo -e "  ${RED}⚠${NC} Some agents are at capacity - complete tasks before claiming new ones"
+fi
+
+if [ "$total_active" -gt 20 ]; then
+    echo -e "  ${YELLOW}⚠${NC} High number of active tasks - consider completing before starting new work"
+fi
+
+echo -e "\n${GREEN}✓${NC} Task limit enforcement is ${GREEN}ACTIVE${NC}"
+echo -e "   Agents cannot claim more than ${MAX_ACTIVE_TASKS:-3} active tasks"


### PR DESCRIPTION
## Summary
Implements automatic task limit enforcement to prevent agents from taking on more than 3 active tasks simultaneously, as described in issue #144.

## Changes
- ✅ Enabled existing `task_lib_enhanced.sh` which already had limit enforcement built
- ✅ Fixed date command compatibility for macOS and Linux
- ✅ Created `status-not-started` GitHub label for proper status tracking
- ✅ Added monitoring dashboard script (`scripts/monitor-task-limits.sh`)
- ✅ Updated Launch Multi-Agent System.md with task management rules

## How It Works
1. When agents claim tasks with `claim_task`, it checks if they're at the 3-task limit
2. Tasks start with `status-not-started` label when claimed
3. Using `start_task` transitions to `status-in-progress` (also enforces limit)
4. The monitoring script shows real-time agent workload and violations

## Current Agent Status
```
infra-agent: 3/3 tasks (AT LIMIT)
backend-agent: 1/3 tasks
quality-agent: 1/3 tasks
Other agents: 0/3 tasks
```

## Testing
Run `./scripts/monitor-task-limits.sh` to see the dashboard showing:
- Agent workload summary
- Stale task detection (>24 hours inactive)
- Task limit enforcement status
- P0 priority issues

## Impact
This prevents agents from overwhelming themselves and ensures better task completion rates by limiting work in progress.

Closes #144